### PR TITLE
Approvals usage collection

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -15490,6 +15490,7 @@ dependencies = [
  "sp-consensus-slots",
  "sp-keystore",
  "sp-maybe-compressed-blob",
+ "sp-runtime",
  "thiserror 1.0.65",
  "zstd 0.12.4",
 ]

--- a/polkadot/node/core/approval-voting/src/import.rs
+++ b/polkadot/node/core/approval-voting/src/import.rs
@@ -457,7 +457,7 @@ pub(crate) async fn handle_new_head<
 
 		state.approvals_usage
 			.entry(session_index)
-			.or_insert(HashMap::with_capacity(n_validators));
+			.or_insert((HashMap::with_capacity(n_validators), n_validators));
 
 		let session_info =
 			match get_session_info(session_info_provider, sender, head, session_index).await {
@@ -657,7 +657,7 @@ pub(crate) mod tests {
 		}
 	}
 
-	fn blank_state() -> State {
+	pub fn blank_state() -> State {
 		State {
 			keystore: Arc::new(LocalKeystore::in_memory()),
 			slot_duration_millis: 6_000,
@@ -667,6 +667,7 @@ pub(crate) mod tests {
 				MAX_BLOCKS_WITH_ASSIGNMENT_TIMESTAMPS,
 			)),
 			no_show_stats: Default::default(),
+			last_session_index: None,
 			approvals_usage: Default::default(),
 		}
 	}

--- a/polkadot/node/core/approval-voting/src/import.rs
+++ b/polkadot/node/core/approval-voting/src/import.rs
@@ -320,6 +320,7 @@ pub struct BlockImportedCandidates {
 	pub block_hash: Hash,
 	pub block_number: BlockNumber,
 	pub block_tick: Tick,
+	pub session_index: SessionIndex,
 	pub imported_candidates: Vec<(CandidateHash, CandidateEntry)>,
 }
 
@@ -455,10 +456,6 @@ pub(crate) async fn handle_new_head<
 			force_approve,
 		} = imported_block_info;
 
-		state.approvals_usage
-			.entry(session_index)
-			.or_insert((HashMap::with_capacity(n_validators), n_validators));
-
 		let session_info =
 			match get_session_info(session_info_provider, sender, head, session_index).await {
 				Some(session_info) => session_info,
@@ -584,6 +581,7 @@ pub(crate) async fn handle_new_head<
 			block_hash,
 			block_number: block_header.number,
 			block_tick,
+			session_index: session_index,
 			imported_candidates: candidate_entries
 				.into_iter()
 				.map(|(h, e)| (h, e.into()))

--- a/polkadot/node/core/approval-voting/src/lib.rs
+++ b/polkadot/node/core/approval-voting/src/lib.rs
@@ -911,7 +911,7 @@ pub struct ApprovalTallyLine {
 	/// Approvals by this validator which our approvals gadget used in marking candidates approved.
 	approval_usages: u32,
 }
-struct ApprovalsTally(Vec<ApprovalTallyLine>);
+struct ApprovalsTally((SessionIndex, Vec<ApprovalTallyLine>));
 
 // Regularly dump the no-show stats at this block number frequency.
 const NO_SHOW_DUMP_FREQUENCY: BlockNumber = 50;
@@ -1192,9 +1192,9 @@ impl State {
 		}
 	}
 
-	fn compute_approvals_tallies(&mut self, session_index: SessionIndex) -> Vec<ApprovalTallyLine> {
+	fn compute_approvals_tallies(&mut self, session_index: SessionIndex) -> ApprovalsTally {
 		match self.approvals_usage.get(&session_index) {
-			None => return vec![],
+			None => return ApprovalsTally((session_index, vec![])),
 			Some((approvals_usage, n_validators)) => {
 				let mut approvals_tallies: Vec<ApprovalTallyLine> = vec![ApprovalTallyLine::default(); *n_validators];
 				approvals_usage.iter().for_each(|(validator_index, usage)| {
@@ -1203,7 +1203,7 @@ impl State {
 					}
 				});
 
-				return approvals_tallies;
+				return ApprovalsTally((session_index, approvals_tallies));
 			}
 		}
 	}

--- a/polkadot/node/core/approval-voting/src/lib.rs
+++ b/polkadot/node/core/approval-voting/src/lib.rs
@@ -2157,6 +2157,8 @@ async fn handle_from_overseer<
 						_ => {},
 					}
 				};
+
+				state.last_session_index = Some(finalized_tip.session());
 			};
 
 			*last_finalized_height = Some(block_number);

--- a/polkadot/node/core/approval-voting/src/lib.rs
+++ b/polkadot/node/core/approval-voting/src/lib.rs
@@ -4151,5 +4151,3 @@ fn compute_delayed_approval_sending_tick(
 	metrics.on_delayed_approval(sign_no_later_than.checked_sub(tick_now).unwrap_or_default());
 	sign_no_later_than
 }
-
-

--- a/polkadot/node/core/approval-voting/src/lib.rs
+++ b/polkadot/node/core/approval-voting/src/lib.rs
@@ -906,15 +906,6 @@ struct State {
 	approvals_usage: HashMap<SessionIndex, Vec<ApprovalTallyLine>>,
 }
 
-/// Our subjective record of what we used from some other validator on the finalized chain
-#[derive(Clone, Debug, Default, PartialEq)]
-pub struct ApprovalTallyLine {
-	/// Approvals by this validator which our approvals gadget used in marking candidates approved.
-	approval_usages: u32,
-}
-
-#[derive(Clone, Debug)]
-struct ApprovalsTally((SessionIndex, Vec<ApprovalTallyLine>));
 
 // Regularly dump the no-show stats at this block number frequency.
 const NO_SHOW_DUMP_FREQUENCY: BlockNumber = 50;
@@ -2114,13 +2105,21 @@ async fn handle_from_overseer<
 			gum::debug!(target: LOG_TARGET, ?block_hash, ?block_number, "Block finalized");
 			let finalized_tip = db.load_block_entry(&block_hash)?.unwrap();
 
+			
 			let is_new_session = match state.last_session_index {
 				Some(last_session) if finalized_tip.session() > last_session => true,
 				Some(_) => false,
-				None => true,
+				None => {
+					// in case of NONE we dont need to share the approvals
+					// usage as we are under an ongoing session
+					state.last_session_index = Some(finalized_tip.session())
+					return false
+				},
 			};
 
 			if is_new_session {
+				// new session started then 
+				// lets compute the previous session approvals usage
 				compute_approvals_usage_and_share(
 					sender,
 					approval_voting_sender,
@@ -2378,22 +2377,29 @@ async fn compute_approvals_usage_and_share<
 	approval_voting_sender: &mut ADSender,
 	state: &mut State,
 	db: &mut OverlayedBackend<'_, impl Backend>,
-	current_finalized_session: u32,
+	current_session: u32,
 	current_finalized: (Hash, u32),
 	last_finalized_height: &mut Option<BlockNumber>
 ) -> SubsystemResult<()> {
+
+	//    0.         1
+	// 1 ... 10 | 11
+
 	let retrieve_size: usize = last_finalized_height
 		.clone()
 		.map_or(current_finalized.1, |b| current_finalized.1 - (b as u32)) as usize;
 
+	// TODO: change fetch ancestry to return not the range 
+	// but all the hashes of a given session so we can
+	// perform on_finalized_block with all the session blocks correctly
 	let finalized_hashes: HashSet<Hash> = fetch_ancestry(
 		sender,
 		current_finalized.0,
 		retrieve_size,
 	).await?.into_iter().collect();
 
-	let mut prev_session_approvals: HashMap<usize, u32> = HashMap::new();
-	let prev = current_finalized_session.saturating_sub(1) as SessionIndex;
+	let mut prev_session_approvals: HashMap<ValidatorIndex, u32> = HashMap::new();
+	let prev = current_session.saturating_sub(1) as SessionIndex;
 	let candidates = match state.candidates_per_session.remove(&prev) {
 		Some(candidates) => candidates,
 		_ => vec![],
@@ -2402,6 +2408,8 @@ async fn compute_approvals_usage_and_share<
 	for c_hash in candidates {
 		match db.load_candidate_entry(&c_hash)? {
 			Some(candidate) => {
+				// TODO: fix the candidate check as it does not
+				// check correclty every finalized session block
 				let on_finalized_block = candidate.block_assignments
 					.keys()
 					.any(|b_hash| finalized_hashes.contains(b_hash));
@@ -2409,7 +2417,7 @@ async fn compute_approvals_usage_and_share<
 				if on_finalized_block {
 					for idx in candidate.approvals.iter_ones() {
 						prev_session_approvals
-							.entry(idx as usize)
+							.entry(idx)
 							.and_modify(|e| *e += 1)
 							.or_insert(0);
 					}
@@ -2418,6 +2426,13 @@ async fn compute_approvals_usage_and_share<
 			_ => {},
 		}
 	};
+
+	if prev_session_approvals.len() > 0 {
+		let message = ApprovalDistributionMessage::DistributeUsages(
+			prev,
+			prev_session_approvals
+		);
+    }
 
 	Ok(())
 }

--- a/polkadot/node/core/approval-voting/src/tests.rs
+++ b/polkadot/node/core/approval-voting/src/tests.rs
@@ -5638,6 +5638,7 @@ fn test_gathering_assignments_statements() {
 			MAX_BLOCKS_WITH_ASSIGNMENT_TIMESTAMPS,
 		)),
 		no_show_stats: NoShowStats::default(),
+		last_session_index: None,
 		approvals_usage: Default::default(),
 	};
 
@@ -5733,6 +5734,7 @@ fn test_observe_assignment_gathering_status() {
 			MAX_BLOCKS_WITH_ASSIGNMENT_TIMESTAMPS,
 		)),
 		no_show_stats: NoShowStats::default(),
+		last_session_index: None,
 		approvals_usage: Default::default(),
 	};
 
@@ -5856,4 +5858,17 @@ fn test_observe_assignment_gathering_status() {
 		.unwrap();
 
 	assert_eq!(value.get_sample_count(), 1);
+}
+
+#[test]
+fn test_computes_approvals_tallies_correctly() {
+	let mut state = import::tests::blank_state();
+
+	let usages = HashMap::from([(ValidatorIndex(0), 10), (ValidatorIndex(1), 8)]);
+	state.approvals_usage.insert(SessionIndex::from(5_u32), (usages, 2));
+
+	let tallies = state.compute_approvals_tallies(SessionIndex::from(5_u32));
+
+	assert_eq!(tallies.get(0).unwrap(), &ApprovalTallyLine{approval_usages: 10});
+	assert_eq!(tallies.get(1).unwrap(), &ApprovalTallyLine{approval_usages: 8});
 }

--- a/polkadot/node/core/approval-voting/src/tests.rs
+++ b/polkadot/node/core/approval-voting/src/tests.rs
@@ -5859,17 +5859,3 @@ fn test_observe_assignment_gathering_status() {
 
 	assert_eq!(value.get_sample_count(), 1);
 }
-
-#[test]
-fn test_computes_approvals_tallies_correctly() {
-	let mut state = import::tests::blank_state();
-
-	let usages = HashMap::from([(ValidatorIndex(0), 10), (ValidatorIndex(1), 8)]);
-	state.approvals_usage.insert(SessionIndex::from(5_u32), (usages, 2));
-
-	let tallies = state.compute_approvals_tallies(SessionIndex::from(5_u32));
-
-	assert_eq!(tallies.0, SessionIndex::from(5_u32));
-	assert_eq!(tallies.1.get(0).unwrap(), &ApprovalTallyLine{approval_usages: 10});
-	assert_eq!(tallies.1.get(1).unwrap(), &ApprovalTallyLine{approval_usages: 8});
-}

--- a/polkadot/node/core/approval-voting/src/tests.rs
+++ b/polkadot/node/core/approval-voting/src/tests.rs
@@ -5638,6 +5638,7 @@ fn test_gathering_assignments_statements() {
 			MAX_BLOCKS_WITH_ASSIGNMENT_TIMESTAMPS,
 		)),
 		no_show_stats: NoShowStats::default(),
+		approvals_usage: Default::default(),
 	};
 
 	for i in 0..200i32 {
@@ -5732,6 +5733,7 @@ fn test_observe_assignment_gathering_status() {
 			MAX_BLOCKS_WITH_ASSIGNMENT_TIMESTAMPS,
 		)),
 		no_show_stats: NoShowStats::default(),
+		approvals_usage: Default::default(),
 	};
 
 	let metrics_inner = MetricsInner {

--- a/polkadot/node/core/approval-voting/src/tests.rs
+++ b/polkadot/node/core/approval-voting/src/tests.rs
@@ -5869,6 +5869,7 @@ fn test_computes_approvals_tallies_correctly() {
 
 	let tallies = state.compute_approvals_tallies(SessionIndex::from(5_u32));
 
-	assert_eq!(tallies.get(0).unwrap(), &ApprovalTallyLine{approval_usages: 10});
-	assert_eq!(tallies.get(1).unwrap(), &ApprovalTallyLine{approval_usages: 8});
+	assert_eq!(tallies.0, SessionIndex::from(5_u32));
+	assert_eq!(tallies.1.get(0).unwrap(), &ApprovalTallyLine{approval_usages: 10});
+	assert_eq!(tallies.1.get(1).unwrap(), &ApprovalTallyLine{approval_usages: 8});
 }

--- a/polkadot/node/network/approval-distribution/Cargo.toml
+++ b/polkadot/node/network/approval-distribution/Cargo.toml
@@ -19,8 +19,9 @@ polkadot-node-primitives = { workspace = true, default-features = true }
 polkadot-node-subsystem = { workspace = true, default-features = true }
 polkadot-node-subsystem-util = { workspace = true, default-features = true }
 polkadot-primitives = { workspace = true, default-features = true }
+polkadot-core-primitives = { workspace = true, default-features = true }
 rand = { workspace = true, default-features = true }
-
+sp-keystore = { workspace = true, default-features = true }
 futures = { workspace = true }
 futures-timer = { workspace = true }
 gum = { workspace = true, default-features = true }

--- a/polkadot/node/network/approval-distribution/src/lib.rs
+++ b/polkadot/node/network/approval-distribution/src/lib.rs
@@ -34,13 +34,14 @@ use polkadot_node_network_protocol::{
 	v3 as protocol_v3, PeerId, UnifiedReputationChange as Rep, ValidationProtocols, View,
 };
 use polkadot_node_primitives::{
-	approval::{
+	SessionInfo,
+	approval::{ 
 		criteria::{AssignmentCriteria, InvalidAssignment},
 		time::{Clock, ClockExt, SystemClock, TICK_TOO_FAR_IN_FUTURE},
 		v1::{BlockApprovalMeta, DelayTranche, RelayVRFStory},
 		v2::{
 			AsBitIndex, AssignmentCertKindV2, CandidateBitfield, IndirectAssignmentCertV2,
-			IndirectSignedApprovalVoteV2,
+			IndirectSignedApprovalVoteV2, SignedApprovalsTally, ApprovalTallyLine
 		},
 	},
 	DISPUTE_WINDOW,
@@ -324,6 +325,13 @@ enum Resend {
 	No,
 }
 
+#[derive(Default)]
+struct FinalizedSession {
+	relay_parent_hash: Hash,
+	session_info: SessionInfo,
+	tallies: HashMap<ValidatorIndex, Vec<SignedApprovalsTally>>
+}
+
 /// The [`State`] struct is responsible for tracking the overall state of the subsystem.
 ///
 /// It tracks metadata about our view of the unfinalized chain,
@@ -333,6 +341,8 @@ pub struct State {
 	/// These two fields are used in conjunction to construct a view over the unfinalized chain.
 	blocks_by_number: BTreeMap<BlockNumber, Vec<Hash>>,
 	blocks: HashMap<Hash, BlockEntry>,
+
+	finalized_sessions: HashMap<SessionIndex, FinalizedSession>
 
 	/// Our view updates to our peers can race with `NewBlocks` updates. We store messages received
 	/// against the directly mentioned blocks in our view in this map until `NewBlocks` is
@@ -1179,7 +1189,74 @@ impl State {
 				)
 				.await;
 			},
+			ValidationProtocols::V3(protocol_v3::ApprovalDistributionMessage::ApprovalsTallies(
+				signed_approvals_tally,
+			)) => {
+				let f_session = match state.finalized_sessions.get_mut(&tally.0) {
+					Some(session) => session,
+					None => return // TODO: include log here
+				}
+				
+				let active_validators = f_session.session_info.active_validator_indices;
+				if active_validators.len() != signed_approvals_tally.tallies.len() {
+					// there are more or less usages than validators 
+					// for the given session
+					// include log and punish the peer
+					return
+				}
+
+				let pubkey = match f_session
+					.session_info
+					.validators
+					.get(signed_approvals_tally.validator_index) 
+				{
+					Some(pubkey) => pubkey,
+					// include log here and punish the peer to give an 
+					// unknown validator index
+					None => return 
+				}
+
+				let approvals_tally = SignedApprovalsTally::unsigned(
+					signed_approvals_tally.session_index,
+					signed_approvals_tally.validator_index.clone(),
+					signed_approvals_tally.tallies,
+				);
+
+				if let Some(sig) = signed_approvals_tally.signature {
+					match approvals_tally.check_signature(pubkey, sig) {
+						Ok(_) => {}
+						// add log here and punish the peer to give and
+						// invalid signature
+						Err(_) => return
+					}
+				} else {
+					// punish the peer for not provide the signature
+				}
+
+				f_session.tallies.insert(
+					signed_approvals_tally.validator_index,
+					signed_approvals_tally.tallies,
+				);
+
+				// TODO: define an timeout or for receiving the 
+				// validators tallies?
+				// OR a min amount like 90% of 
+				// maybe store this in a auxiliary database so
+				// we don't care about storing everything in memory.
+				if f_session.tallies.len() == active_validators.len() {
+					calculate_and_circulate_medians(f_session);
+				} 
+			},
+			// ValidationProtocol::V3(protocol_v3::ApprovalDistributionMessage::ApprovalsMedians(
+			// 	medians,
+			// )) => {
+
+			// }
 		}
+	}
+
+	fn calculate_and_circulate_medians(finalized_session: &mut FinalizedSession) {
+		let mut approval_usage_medians: Vec<u32> = vec![finalized_session.];
 	}
 
 	// handle a peer view change: requires that the peer is already connected
@@ -2694,8 +2771,23 @@ impl ApprovalDistribution {
 				// activated and deactivated heads hence are irrelevant to this subsystem, other
 				// than for tracing purposes.
 			},
-			FromOrchestra::Signal(OverseerSignal::BlockFinalized(_hash, number)) => {
+			FromOrchestra::Signal(OverseerSignal::BlockFinalized(hash, number)) => {
 				gum::trace!(target: LOG_TARGET, number = %number, "finalized signal");
+				if let Some(block_entry) = state.blocks.get(&hash) {
+					let ExtendedSessionInfo { ref session_info, .. } = match session_info_provider
+						.get_session_info(runtime_api_sender, hash)
+						.await {
+							Ok(ext) => ext;
+							_ => return true;
+						}
+					
+					state.finalized_sessions.insert(block_entry.session, FinalizedSession{
+						relay_block_hash: hash.clone(),
+						session_info: session_info.clone(),
+						tallies: vec![],
+					})
+				}
+				
 				state.handle_block_finalized(network_sender, &self.metrics, number).await;
 			},
 			FromOrchestra::Signal(OverseerSignal::Conclude) => return true,
@@ -2807,6 +2899,9 @@ impl ApprovalDistribution {
 			ApprovalDistributionMessage::ApprovalCheckingLagUpdate(lag) => {
 				gum::debug!(target: LOG_TARGET, lag, "Received `ApprovalCheckingLagUpdate`");
 				state.approval_checking_lag = lag;
+			},
+			ApprovalDistributionMessage::DistributeUsages(session, usages) => {
+
 			},
 		}
 	}

--- a/polkadot/node/network/approval-distribution/src/lib.rs
+++ b/polkadot/node/network/approval-distribution/src/lib.rs
@@ -41,11 +41,12 @@ use polkadot_node_primitives::{
 		v1::{BlockApprovalMeta, DelayTranche, RelayVRFStory},
 		v2::{
 			AsBitIndex, AssignmentCertKindV2, CandidateBitfield, IndirectAssignmentCertV2,
-			IndirectSignedApprovalVoteV2, SignedApprovalsTally, ApprovalTallyLine
+			IndirectSignedApprovalVoteV2, SignedApprovalsTally, SignedApprovalsMedian, ApprovalTallyLine
 		},
 	},
 	DISPUTE_WINDOW,
 };
+use bitvec::{prelude::*, vec::BitVec};
 use polkadot_node_subsystem::{
 	messages::{
 		ApprovalDistributionMessage, ApprovalVotingMessage, CheckedIndirectAssignment,
@@ -68,6 +69,7 @@ use std::{
 	sync::Arc,
 	time::Duration,
 };
+use sp_keystore::KeystorePtr;
 
 /// Approval distribution metrics.
 pub mod metrics;
@@ -327,9 +329,14 @@ enum Resend {
 
 #[derive(Default)]
 struct FinalizedSession {
+	known_by: PeerKnowledge,
+	session_index: SessionIndex,
 	relay_parent_hash: Hash,
 	session_info: SessionInfo,
-	tallies: HashMap<ValidatorIndex, Vec<SignedApprovalsTally>>
+	tallies: HashMap<ValidatorIndex, SignedApprovalsTally>
+
+	medians_hash_agree: HashMap<Hash, BitVec<u8, bitvec::order::Lsb0>>
+	medians: HashMap<ValidatorIndex, SignedApprovalsMedian>
 }
 
 /// The [`State`] struct is responsible for tracking the overall state of the subsystem.
@@ -341,7 +348,8 @@ pub struct State {
 	/// These two fields are used in conjunction to construct a view over the unfinalized chain.
 	blocks_by_number: BTreeMap<BlockNumber, Vec<Hash>>,
 	blocks: HashMap<Hash, BlockEntry>,
-
+	
+	keystore: KeystorePtr,
 	finalized_sessions: HashMap<SessionIndex, FinalizedSession>
 
 	/// Our view updates to our peers can race with `NewBlocks` updates. We store messages received
@@ -720,8 +728,12 @@ enum PendingMessage {
 #[overseer::contextbounds(ApprovalDistribution, prefix = self::overseer)]
 impl State {
 	/// Build State with specified slot duration.
-	pub fn with_config(slot_duration_millis: u64) -> Self {
-		Self { slot_duration_millis, ..Default::default() }
+	pub fn with_config(slot_duration_millis: u64, keystore: KeystorePtr) -> Self {
+		Self { 
+			slot_duration_millis, 
+			keystore,
+			..Default::default(),
+		}
 	}
 
 	async fn handle_network_msg<
@@ -1192,7 +1204,7 @@ impl State {
 			ValidationProtocols::V3(protocol_v3::ApprovalDistributionMessage::ApprovalsTallies(
 				signed_approvals_tally,
 			)) => {
-				let f_session = match state.finalized_sessions.get_mut(&tally.0) {
+				let f_session = match state.finalized_sessions.get_mut(signed_approvals_tally.session_index) {
 					Some(session) => session,
 					None => return // TODO: include log here
 				}
@@ -1231,11 +1243,13 @@ impl State {
 					}
 				} else {
 					// punish the peer for not provide the signature
+					return
 				}
 
+				let v_idx = signed_approvals_tally.validator_index.clone();
 				f_session.tallies.insert(
-					signed_approvals_tally.validator_index,
-					signed_approvals_tally.tallies,
+					v_idx,
+					signed_approvals_tally,
 				);
 
 				// TODO: define an timeout or for receiving the 
@@ -1244,19 +1258,123 @@ impl State {
 				// maybe store this in a auxiliary database so
 				// we don't care about storing everything in memory.
 				if f_session.tallies.len() == active_validators.len() {
-					calculate_and_circulate_medians(f_session);
+					self.calculate_and_circulate_medians(f_session);
 				} 
 			},
-			// ValidationProtocol::V3(protocol_v3::ApprovalDistributionMessage::ApprovalsMedians(
-			// 	medians,
-			// )) => {
+			ValidationProtocol::V3(protocol_v3::ApprovalDistributionMessage::ApprovalsMedians(
+				signed_approvals_medians,
+			)) => {
+				let f_session = match state.finalized_sessions.get_mut(signed_approvals_medians.session_index) {
+					Some(session) => session,
+					None => return // TODO: include log here
+				}
+				let current_validator_idx = signed_approvals_medians.validator_index;
+				let active_validators = f_session.session_info.active_validator_indices;
+				if active_validators.len() != signed_approvals_medians.medians.len() {
+					// there are more or less usages than validators 
+					// for the given session
+					// include log and punish the peer
+					return
+				}
 
-			// }
+				let pubkey = match f_session
+					.session_info
+					.validators
+					.get(current_validator_idx) 
+				{
+					Some(pubkey) => pubkey,
+					// include log here and punish the peer to give an 
+					// unknown validator index
+					None => return 
+				}
+
+				let approvals_medians = SignedApprovalsTally::unsigned(
+					signed_approvals_medians.session_index,
+					current_validator_idx.clone(),
+					signed_approvals_medians.medians,
+				);
+
+				if let Some(sig) = signed_approvals_medians.signature {
+					match approvals_medians.check_signature(pubkey, sig) {
+						Ok(_) => {}
+						// add log here and punish the peer to give and
+						// invalid signature
+						Err(_) => return
+					}
+				} else {
+					// punish the peer for not provide the signature
+					return
+				}
+
+				f_session.medians.insert(
+					current_validator_idx,
+					approvals_medians,
+				);
+
+				let medians_hash = Hash::hash(&signed_approvals_medians.medians);
+
+				f_session
+					.medians_hash_agree
+					.entry(medians_hash)
+					.and_modify(|agrees| {
+						if agrees.len() <= current_validator_idx {
+							agrees.resize(current_validator_idx + 1, false);
+						}
+						agrees.set(current_validator_idx, true);
+					})
+					.or_insert_with(|| {
+						let mut agrees = bitvec![u8, Lsb0; 0; current_validator_idx + 1];
+						agrees.set(current_validator_idx as usize, true);
+						agrees
+					})
+			}
 		}
 	}
 
-	fn calculate_and_circulate_medians(finalized_session: &mut FinalizedSession) {
-		let mut approval_usage_medians: Vec<u32> = vec![finalized_session.];
+	fn calculate_and_circulate_medians(&self, finalized_session: &mut FinalizedSession, num_validators: usize) {
+		let mut approval_usages_medians = Vec::new();
+		let signed_approvals_tallies: Vec<SignedApprovalsTally> = finalized_session.tallies.into_values().collect();
+
+		for i in 0..num_validators {
+			let mut v: Vec<u32> = signed_approvals_tallies.iter().map(|sat| sat.tallies[i].approval_usages);
+			v.sort();
+			approval_usages_medians.push(v[num_validators/2]);
+		}
+
+		let (local_pubkey, local_validator_idx) = match polkadot_node_subsystem_util::signing_key_and_index(
+			finalized_session.session_info.validators.iter(),
+			&self.keystore,
+		) {
+			Some((pubkey, v_idx)) => (pubkey, v_idx),
+			None => return // TODO: include logging here
+		}
+
+		let mut approvals_medians = SignedApprovalsMedian::unsigned(
+			session, 
+			local_validator_idx.clone(), 
+			tallies,
+			approval_usages_medians.clone(),
+		)
+
+		let payload = approvals_medians.encode();
+		match polkadot_node_subsystem_util::sign(
+			&state.keystore,
+			&local_pubkey,
+			&payload,
+		) {
+			Ok(Some(sig)) => approvals_medians.signature = Some(sig);
+			_ => return // TODO: failed to sign, include logging here
+		}
+
+		finalized_session.medians.insert(local_validator_idx, approvals_medians);
+
+		let medians_hash = Hash::hash(&approval_usages_medians);
+		let mut agrees = bitvec![u8, Lsb0; 0; local_validator_idx + 1];
+		agrees.set(local_validator_idx as usize, true);
+
+		finalized_session.medians_hash_agree.insert(medians_hash, agrees);
+
+		// TODO: share with the network
 	}
 
 	// handle a peer view change: requires that the peer is already connected
@@ -2781,10 +2899,13 @@ impl ApprovalDistribution {
 							_ => return true;
 						}
 					
-					state.finalized_sessions.insert(block_entry.session, FinalizedSession{
+					state.finalized_sessions.insert(block_entry.session.clone(), FinalizedSession{
+						session_index: block_entry.session,
 						relay_block_hash: hash.clone(),
 						session_info: session_info.clone(),
 						tallies: vec![],
+						medians_hash_agree: Default::default(),
+						medians: Default::default(),
 					})
 				}
 				
@@ -2901,7 +3022,54 @@ impl ApprovalDistribution {
 				state.approval_checking_lag = lag;
 			},
 			ApprovalDistributionMessage::DistributeUsages(session, usages) => {
+				// check for the finalized session
+				let f_session = match state.finalized_sessions.get_mut(&session) {
+					Some(session) => session,
+					None => return // TODO: include a logging here
+				}
 
+				// compute the signed approvals tally
+				let (signed_approvals_tally, validator_idx) = {
+					let mut tallies: Vec<ApprovalTallyLine> = !vec[
+						Default::default(),
+						f_session.session_info.active_validator_indices.len(),
+					];
+
+					for (v_idx, usage) in usages.iter() {
+						tallies[v_idx] = ApprovalTallyLine{
+							approval_usages: usage,
+						};
+					}
+
+					let (local_pubkey, local_validator_idx) = match polkadot_node_subsystem_util::signing_key_and_index(
+						session_info.validators.iter(),
+						&state.keystore,
+					) {
+						Some((pubkey, v_idx)) => (pubkey, v_idx),
+						None => return // TODO: include logging here
+					}
+
+					let mut approvals_tally = SignedApprovalsTally::unsigned(
+						session, local_validator_idx.clone(), tallies,
+					);
+
+					let payload = approvals_tally.encode();
+					match polkadot_node_subsystem_util::sign(
+						&state.keystore,
+						&local_pubkey,
+						&payload,
+					) {
+						Ok(Some(sig)) => approvals_tally.signature = Some(sig);
+						_ => return // TODO: failed to sign, include logging here
+					}
+
+					(approvals_tally, local_validator_idx)
+				}
+
+				// import the tallies there using the local validator index
+				f_session.insert(validator_idx, signed_approvals_tally)
+
+				// TODO: share with the peers
 			},
 		}
 	}

--- a/polkadot/node/network/protocol/src/lib.rs
+++ b/polkadot/node/network/protocol/src/lib.rs
@@ -567,6 +567,7 @@ pub mod v3 {
 
 	use polkadot_node_primitives::approval::v2::{
 		CandidateBitfield, IndirectAssignmentCertV2, IndirectSignedApprovalVoteV2,
+		ApprovalTallyLine, SignedApprovalsTally, SignedApprovalsMedians
 	};
 
 	/// This parts of the protocol did not change from v2, so just alias them in v3.
@@ -740,6 +741,13 @@ pub mod v3 {
 		/// Approvals for candidates in some recent, unfinalized block.
 		#[codec(index = 1)]
 		Approvals(Vec<IndirectSignedApprovalVoteV2>),
+
+		// TODO: maybe use a provided Hash
+		#[codec(index = 2)]
+		ApprovalsTallies(SignedApprovalsTally)
+
+		#[codec(index = 3)]
+		ApprovalsMedians(SignedApprovalsMedians)
 	}
 
 	/// Dummy network message type, so we will receive connect/disconnect events.

--- a/polkadot/node/primitives/Cargo.toml
+++ b/polkadot/node/primitives/Cargo.toml
@@ -26,6 +26,7 @@ sp-application-crypto = { workspace = true, default-features = true }
 sp-consensus-babe = { workspace = true, default-features = true }
 sp-consensus-slots = { workspace = true }
 sp-keystore = { workspace = true, default-features = true }
+sp-runtime = { workspace = true }
 sp-maybe-compressed-blob = { workspace = true, default-features = true }
 thiserror = { workspace = true }
 

--- a/polkadot/node/primitives/src/approval/mod.rs
+++ b/polkadot/node/primitives/src/approval/mod.rs
@@ -224,11 +224,13 @@ pub mod v2 {
 	pub use sp_consensus_babe::{
 		Randomness, Slot, VrfPreOutput, VrfProof, VrfSignature, VrfTranscript,
 	};
+	use sp_runtime::traits::AppVerify;
 	use std::ops::BitOr;
 
 	use bitvec::{prelude::Lsb0, vec::BitVec};
 	use polkadot_primitives::{
 		CandidateIndex, CoreIndex, Hash, ValidatorIndex, ValidatorSignature,
+		SessionIndex, ValidatorId,
 	};
 
 	/// A static context associated with producing randomness for a core.
@@ -535,6 +537,109 @@ pub mod v2 {
 		pub validator: ValidatorIndex,
 		/// The signature by the validator.
 		pub signature: ValidatorSignature,
+	}
+
+	/// Our subjective record of what we used from some other validator on the finalized chain
+	#[derive(Clone, Copy, Debug, Default, Encode, Decode, Eq, PartialEq)]
+	pub struct ApprovalTallyLine {
+		/// Approvals by this validator which our approvals gadget used in marking candidates approved.
+		pub approval_usages: u32,
+	}
+	
+	/// A signed approvals tally that contains the collected approvals
+	/// usage throughout a given session
+	#[derive(Clone, Debug, Encode, Decode, Eq, PartialEq)]
+	pub struct SignedApprovalsTally {
+		pub session_index: SessionIndex,
+		pub validator_index: ValidatorIndex,
+		pub tallies: Vec<ApprovalTallyLine>,
+		pub signature: Option<ValidatorSignature>,
+	}
+
+	impl SignedApprovalsTally {
+		/// returns a SignedApprovalsTally withouth the signature
+		pub fn unsigned(
+			session_index: SessionIndex,
+			validator_index: ValidatorIndex,
+			tallies: Vec<ApprovalTallyLine>
+		) -> Self {
+			return Self {
+				session_index,
+				validator_index,
+				tallies,
+				signature: None,
+			}
+		}
+
+		/// given a SignedApprovalsTally returns the encoded payload
+		/// to be signed or checked
+		pub fn encode(&self) -> Vec<u8> {
+			const MAGIC: [u8; 4] = *b"APTL";
+			(MAGIC, self.session_index, self.validator_index, self.tallies.clone()).encode()
+		}
+
+		/// given a SignedApprovalsTally checks if the validator
+		/// public key can verify the signature sucessfully
+		pub fn check_signature(
+			&self,
+			validator_public: &ValidatorId,
+			validator_signature: &ValidatorSignature,
+		) -> Result<(), ()> {
+			let payload = self.encode();
+
+			if validator_signature.verify(&payload[..], &validator_public) {
+				Ok(())
+			} else {
+				Err(())
+			}
+		}
+	}
+
+	#[derive(Clone, Debug, Encode, Decode, Eq, PartialEq)]
+	pub struct SignedApprovalsMedian {
+		pub session_index: SessionIndex,
+		pub validator_index: ValidatorIndex,
+		pub medians: Vec<u32>,
+		pub signature: Option<ValidatorSignature>,
+	}
+
+	impl SignedApprovalsMedian {
+		/// returns a SignedApprovalsTally withouth the signature
+		pub fn unsigned(
+			session_index: SessionIndex,
+			validator_index: ValidatorIndex,
+			medians: Vec<u32>
+		) -> Self {
+			return Self {
+				session_index,
+				validator_index,
+				medians,
+				signature: None,
+			}
+		}
+
+		/// given a SignedApprovalsTally returns the encoded payload
+		/// to be signed or checked
+		pub fn encode(&self) -> Vec<u8> {
+			const MAGIC: [u8; 4] = *b"APMD";
+			(MAGIC, self.session_index, self.validator_index, self.medians.clone()).encode()
+		}
+
+		/// given a SignedApprovalsTally checks if the validator
+		/// public key can verify the signature sucessfully
+		pub fn check_signature(
+			&self,
+			validator_public: &ValidatorId,
+			validator_signature: &ValidatorSignature,
+		) -> Result<(), ()> {
+			let payload = self.encode();
+
+			if validator_signature.verify(&payload[..], &validator_public) {
+				Ok(())
+			} else {
+				Err(())
+			}
+		}
 	}
 }
 

--- a/polkadot/node/subsystem-types/src/messages.rs
+++ b/polkadot/node/subsystem-types/src/messages.rs
@@ -34,7 +34,7 @@ use polkadot_node_network_protocol::{
 use polkadot_node_primitives::{
 	approval::{
 		v1::{BlockApprovalMeta, DelayTranche},
-		v2::{CandidateBitfield, IndirectAssignmentCertV2, IndirectSignedApprovalVoteV2},
+		v2::{CandidateBitfield, IndirectAssignmentCertV2, IndirectSignedApprovalVoteV2, SignedApprovalsTally},
 	},
 	AvailableData, BabeEpoch, BlockWeight, CandidateVotes, CollationGenerationConfig,
 	CollationSecondedSignal, DisputeMessage, DisputeStatus, ErasureChunk, PoV,
@@ -1208,6 +1208,7 @@ pub enum ApprovalDistributionMessage {
 	),
 	/// Approval checking lag update measured in blocks.
 	ApprovalCheckingLagUpdate(BlockNumber),
+	DistributeUsages(SessionIndex, HashMap<ValidatorIndex, u32>),
 }
 
 /// Message to the Gossip Support subsystem.


### PR DESCRIPTION
## Description

- Collect approvals usage throughout the session
- After the session ends (on block finalized) collects the rewards and compute the ApprovalTallyLine