### PR TITLE
wip: Speculative Availability

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -16042,6 +16042,7 @@ name = "polkadot-node-subsystem-util"
 version = "7.0.0"
 dependencies = [
  "assert_matches",
+ "bitvec",
  "fatality",
  "futures",
  "itertools 0.11.0",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -15745,7 +15745,6 @@ dependencies = [
 name = "polkadot-node-core-provisioner"
 version = "7.0.0"
 dependencies = [
- "bitvec",
  "fatality",
  "futures",
  "futures-timer",

--- a/cumulus/client/relay-chain-inprocess-interface/src/lib.rs
+++ b/cumulus/client/relay-chain-inprocess-interface/src/lib.rs
@@ -419,6 +419,7 @@ fn build_polkadot_full_node(
 		keep_finalized_for: None,
 		invulnerable_ah_collators: HashSet::new(),
 		collator_protocol_hold_off: None,
+		speculative_availability: false,
 	};
 
 	let (relay_chain_full_node, paranode_req_receiver) = match config.network.network_backend {

--- a/polkadot/cli/src/cli.rs
+++ b/polkadot/cli/src/cli.rs
@@ -166,6 +166,10 @@ pub struct RunCmd {
 	///  **Dangerous!** Do not touch unless explicitly advised to.
 	#[arg(long, hide = true)]
 	pub collator_protocol_hold_off: Option<u64>,
+
+	/// Enable speculative availability requests via Prospective Parachains. Defaults to disabled.
+	#[arg(long = "speculative-availability")]
+	pub speculative_availability: bool,
 }
 
 #[allow(missing_docs)]

--- a/polkadot/cli/src/command.rs
+++ b/polkadot/cli/src/command.rs
@@ -292,6 +292,7 @@ where
 				keep_finalized_for: cli.run.keep_finalized_for,
 				invulnerable_ah_collators,
 				collator_protocol_hold_off,
+				speculative_availability: cli.run.speculative_availability,
 			},
 		)
 		.map(|full| full.task_manager)?;

--- a/polkadot/node/core/av-store/src/lib.rs
+++ b/polkadot/node/core/av-store/src/lib.rs
@@ -1280,15 +1280,7 @@ fn store_chunk(
 			write_chunk(&mut tx, config, &candidate_hash, validator_index, &chunk);
 			write_meta(&mut tx, config, &candidate_hash, &meta);
 		},
-		None => {
-			gum::debug!(
-				target: LOG_TARGET,
-				?candidate_hash,
-				validator_index = %validator_index.0,
-				"Cannot store chunk for unknown validator index.",
-			);
-			return Ok(false) // out of bounds.
-		},
+		None => return Ok(false) // out of bounds.
 	}
 
 	gum::debug!(

--- a/polkadot/node/core/av-store/src/lib.rs
+++ b/polkadot/node/core/av-store/src/lib.rs
@@ -1267,24 +1267,7 @@ fn store_chunk(
 
 	let mut meta = match load_meta(db, config, &candidate_hash)? {
 		Some(m) => m,
-		None => {
-			// TODO: revise this, this is a really bad hack
-			let now = SystemTime::now().duration_since(UNIX_EPOCH)?;
-			let meta = CandidateMeta {
-				state: State::Unavailable(now.into()),
-				data_available: false,
-				chunks_stored: bitvec::bitvec![u8, BitOrderLsb0; 0; 12],
-			};
-			
-			gum::debug!(
-				target: LOG_TARGET,
-				?candidate_hash,
-				validator_index = %validator_index.0,
-				"Cannot store chunk for unknown candidate.",
-			);
-			// return Ok(false) // we weren't informed of this candidate by import events.
-			meta
-		},
+		None => return Ok(false), // we weren't informed of this candidate by import events.
 	};
 
 	match meta.chunks_stored.get(validator_index.0 as usize).map(|b| *b) {

--- a/polkadot/node/core/av-store/src/lib.rs
+++ b/polkadot/node/core/av-store/src/lib.rs
@@ -1249,7 +1249,24 @@ fn store_chunk(
 
 	let mut meta = match load_meta(db, config, &candidate_hash)? {
 		Some(m) => m,
-		None => return Ok(false), // we weren't informed of this candidate by import events.
+		None => {
+			// TODO: revise this, this is a really bad hack
+			let now = SystemTime::now().duration_since(UNIX_EPOCH)?;
+			let meta = CandidateMeta {
+				state: State::Unavailable(now.into()),
+				data_available: false,
+				chunks_stored: bitvec::bitvec![u8, BitOrderLsb0; 0; 12],
+			};
+			
+			gum::debug!(
+				target: LOG_TARGET,
+				?candidate_hash,
+				validator_index = %validator_index.0,
+				"Cannot store chunk for unknown candidate.",
+			);
+			// return Ok(false) // we weren't informed of this candidate by import events.
+			meta
+		},
 	};
 
 	match meta.chunks_stored.get(validator_index.0 as usize).map(|b| *b) {
@@ -1260,7 +1277,15 @@ fn store_chunk(
 			write_chunk(&mut tx, config, &candidate_hash, validator_index, &chunk);
 			write_meta(&mut tx, config, &candidate_hash, &meta);
 		},
-		None => return Ok(false), // out of bounds.
+		None => {
+			gum::debug!(
+				target: LOG_TARGET,
+				?candidate_hash,
+				validator_index = %validator_index.0,
+				"Cannot store chunk for unknown validator index.",
+			);
+			return Ok(false) // out of bounds.
+		},
 	}
 
 	gum::debug!(

--- a/polkadot/node/core/provisioner/Cargo.toml
+++ b/polkadot/node/core/provisioner/Cargo.toml
@@ -12,7 +12,6 @@ repository.workspace = true
 workspace = true
 
 [dependencies]
-bitvec = { features = ["alloc"], workspace = true }
 fatality = { workspace = true }
 futures = { workspace = true }
 futures-timer = { workspace = true }

--- a/polkadot/node/network/availability-distribution/src/error.rs
+++ b/polkadot/node/network/availability-distribution/src/error.rs
@@ -88,6 +88,12 @@ pub enum Error {
 
 	#[error("Erasure coding error: {0}")]
 	ErasureCoding(#[from] polkadot_erasure_coding::Error),
+
+	#[error("Expected a block header to be returned")]
+	NoSuchBlockHeader,
+
+	#[error("Error from subsystem-util: {0}")]
+	SubsystemUtil(#[from] polkadot_node_subsystem_util::Error),
 }
 
 /// General result abbreviation type alias.
@@ -112,7 +118,9 @@ pub fn log_error(
 				JfyiError::QueryAvailableDataResponseChannel(_) |
 				JfyiError::QueryChunkResponseChannel(_) |
 				JfyiError::FailedNodeFeatures(_) |
-				JfyiError::ErasureCoding(_) => gum::warn!(target: LOG_TARGET, error = %jfyi, ctx),
+				JfyiError::ErasureCoding(_) |
+				JfyiError::NoSuchBlockHeader |
+				JfyiError::SubsystemUtil(_) => gum::warn!(target: LOG_TARGET, error = %jfyi, ctx),
 				JfyiError::FetchPoV(_) |
 				JfyiError::SendResponse |
 				JfyiError::NoSuchPoV |

--- a/polkadot/node/network/availability-distribution/src/error.rs
+++ b/polkadot/node/network/availability-distribution/src/error.rs
@@ -94,6 +94,9 @@ pub enum Error {
 
 	#[error("Error from subsystem-util: {0}")]
 	SubsystemUtil(#[from] polkadot_node_subsystem_util::Error),
+
+	#[error("Retrieving response from Availability Store unexpectedly failed")]
+	AvailabilityStore,
 }
 
 /// General result abbreviation type alias.
@@ -120,7 +123,8 @@ pub fn log_error(
 				JfyiError::FailedNodeFeatures(_) |
 				JfyiError::ErasureCoding(_) |
 				JfyiError::NoSuchBlockHeader |
-				JfyiError::SubsystemUtil(_) => gum::warn!(target: LOG_TARGET, error = %jfyi, ctx),
+				JfyiError::SubsystemUtil(_) |
+				JfyiError::AvailabilityStore => gum::warn!(target: LOG_TARGET, error = %jfyi, ctx),
 				JfyiError::FetchPoV(_) |
 				JfyiError::SendResponse |
 				JfyiError::NoSuchPoV |

--- a/polkadot/node/network/availability-distribution/src/metrics.rs
+++ b/polkadot/node/network/availability-distribution/src/metrics.rs
@@ -31,6 +31,12 @@ pub const FAILED: &'static str = "failed";
 /// Label for chunks/PoVs that could not be served, because they were not available.
 pub const NOT_FOUND: &'static str = "not-found";
 
+/// Label for scheduled core origin.
+pub const SCHEDULED: &'static str = "scheduled";
+
+/// Label for occupied core origin.
+pub const OCCUPIED: &'static str = "occupied";
+
 /// Availability Distribution metrics.
 #[derive(Clone, Default)]
 pub struct Metrics(Option<MetricsInner>);
@@ -65,9 +71,9 @@ impl Metrics {
 	}
 
 	/// Increment counter on fetched labels.
-	pub fn on_fetch(&self, label: &'static str) {
+	pub fn on_fetch(&self, label: &'static str, origin: &'static str) {
 		if let Some(metrics) = &self.0 {
-			metrics.fetched_chunks.with_label_values(&[label]).inc()
+			metrics.fetched_chunks.with_label_values(&[label, origin]).inc()
 		}
 	}
 
@@ -109,7 +115,7 @@ impl metrics::Metrics for Metrics {
 						"polkadot_parachain_fetched_chunks_total",
 						"Total number of fetched chunks.",
 					),
-					&["success"]
+					&["success", "origin"],
 				)?,
 				registry,
 			)?,

--- a/polkadot/node/network/availability-distribution/src/requester/fetch_task/mod.rs
+++ b/polkadot/node/network/availability-distribution/src/requester/fetch_task/mod.rs
@@ -36,7 +36,7 @@ use polkadot_node_subsystem::{
 };
 use polkadot_primitives::{
 	AuthorityDiscoveryId, BlakeTwo256, CandidateHash, ChunkIndex, GroupIndex, Hash, HashT,
-	OccupiedCore, SessionIndex,
+	SessionIndex,
 };
 use sc_network::ProtocolName;
 

--- a/polkadot/node/network/availability-distribution/src/requester/fetch_task/mod.rs
+++ b/polkadot/node/network/availability-distribution/src/requester/fetch_task/mod.rs
@@ -321,50 +321,15 @@ impl RunningTask {
 				},
 			};
 
-			gum::info!(
-				target: LOG_TARGET,
-				validator = ?validator,
-				relay_parent = ?self.relay_parent,
-				group_index = ?self.group_index,
-				session_index = ?self.session_index,
-				chunk_index = ?self.request.index,
-				candidate_hash = ?self.request.candidate_hash,
-				"Received erasure chunk from validator",
-			);
-
 			// Data genuine?
 			if !self.validate_chunk(&validator, &chunk, self.chunk_index) {
 				bad_validators.push(validator);
 				continue
 			}
 
-			gum::info!(
-				target: LOG_TARGET,
-				validator = ?validator,
-				relay_parent = ?self.relay_parent,
-				group_index = ?self.group_index,
-				session_index = ?self.session_index,
-				chunk_index = ?self.request.index,
-				candidate_hash = ?self.request.candidate_hash,
-				origin = ?self.origin,
-				"Erasure chunk validated successfully",
-			);
-
 			// Ok, let's store it and be happy:
 			self.store_chunk(chunk).await;
 			succeeded = true;
-
-			gum::info!(
-				target: LOG_TARGET,
-				validator = ?validator,
-				relay_parent = ?self.relay_parent,
-				group_index = ?self.group_index,
-				session_index = ?self.session_index,
-				chunk_index = ?self.request.index,
-				candidate_hash = ?self.request.candidate_hash,
-				origin = ?self.origin,
-				"Erasure chunk stored successfully",
-			);
 			break
 		}
 		if succeeded {

--- a/polkadot/node/network/availability-distribution/src/requester/mod.rs
+++ b/polkadot/node/network/availability-distribution/src/requester/mod.rs
@@ -72,7 +72,17 @@ struct CoreInfo {
 	erasure_root: Hash,
 	/// The group index of the group responsible for the candidate.
 	group_responsible: GroupIndex,
+	/// The origin of the CoreInfo, whether from occupied or scheduled cores.
+	origin: CoreInfoOrigin,
 }
+
+/// Origin of CoreInfo.  Whether it was created by calling prospective parachains for scheduled
+/// candidates, or by querying occupied cores for already backed candidates.
+#[derive(Debug, Clone)]
+enum CoreInfoOrigin {
+	Occupied,
+	Scheduled,
+}	
 
 /// Requester takes care of requesting erasure chunks from backing groups and stores them in the
 /// av store.
@@ -201,6 +211,7 @@ impl Requester {
 						relay_parent: receipt.descriptor.relay_parent(),
 						erasure_root: receipt.descriptor.erasure_root(),
 						group_responsible: get_group_index_for_backed_candidate(sender, core_index, leaf).await?,
+						origin: CoreInfoOrigin::Scheduled,
 					},
 				);
 				gum::info!(
@@ -265,6 +276,7 @@ impl Requester {
 							relay_parent: occ.candidate_descriptor.relay_parent(),
 							erasure_root: occ.candidate_descriptor.erasure_root(),
 							group_responsible: occ.group_responsible,
+							origin: CoreInfoOrigin::Occupied,
 						},
 					);
 					gum::info!(

--- a/polkadot/node/network/availability-distribution/src/requester/mod.rs
+++ b/polkadot/node/network/availability-distribution/src/requester/mod.rs
@@ -111,6 +111,9 @@ pub struct Requester {
 
 	/// Mapping of the req-response protocols to the full protocol names.
 	req_protocol_names: ReqProtocolNames,
+
+	/// Whether speculative availability requests are enabled.
+	speculative_availability: bool,
 }
 
 #[overseer::contextbounds(AvailabilityDistribution, prefix = self::overseer)]
@@ -122,7 +125,7 @@ impl Requester {
 	///
 	/// You must feed it with `ActiveLeavesUpdate` via `update_fetching_heads` and make it progress
 	/// by advancing the stream.
-	pub fn new(req_protocol_names: ReqProtocolNames, metrics: Metrics) -> Self {
+	pub fn new(req_protocol_names: ReqProtocolNames, metrics: Metrics, speculative_availability: bool) -> Self {
 		let (tx, rx) = mpsc::channel(1);
 		Requester {
 			fetches: HashMap::new(),
@@ -131,6 +134,7 @@ impl Requester {
 			rx,
 			metrics,
 			req_protocol_names,
+			speculative_availability,
 		}
 	}
 
@@ -246,8 +250,6 @@ impl Requester {
 		)
 		.await?;
 
-		let scheduled_cores = self.request_backable_candidates_core_info(ctx, new_head).await?;
-
 		// Also spawn or bump tasks for candidates in ancestry in the same session.
 		for hash in std::iter::once(leaf).chain(ancestors_in_session) {
 			let cores = get_occupied_cores(sender, hash).await?;
@@ -298,54 +300,58 @@ impl Requester {
 			self.add_cores(ctx, runtime, leaf, leaf_session_index, cores).await?;
 		}
 
-		if scheduled_cores.len() > 0 {
-			gum::info!(
-				target: LOG_TARGET,
-				?scheduled_cores,
-				"Adding scheduled cores"
-			);
+		if self.speculative_availability {
+			let scheduled_cores = self.request_backable_candidates_core_info(ctx, new_head).await?;
+			if scheduled_cores.len() > 0 {
+				gum::info!(
+					target: LOG_TARGET,
+					?scheduled_cores,
+					"Adding scheduled cores"
+				);
 
-			let candidate_hashes = scheduled_cores.iter().map(|(_, core_info)| core_info.candidate_hash).collect::<HashSet<_>>();
-			
-			let session_info = self
-				.session_cache
-				.get_session_info(
-					ctx,
-					runtime,
-					// We use leaf here, the relay_parent must be in the same session as
-					// the leaf. This is guaranteed by runtime which ensures that cores are
-					// cleared at session boundaries. At the same time, only leaves are
-					// guaranteed to be fetchable by the state trie.
-					leaf,
-					leaf_session_index,
-				)
-				.await
-				.map_err(|err| {
-					gum::warn!(
-						target: LOG_TARGET,
-						error = ?err,
-						"Failed to spawn a fetch task"
-					);
-					err
-				})?;
-
-			if let Some(session_info) = session_info {
-				let num_validators =
-					session_info.validator_groups.iter().fold(0usize, |mut acc, group| {
-						acc = acc.saturating_add(group.len());
-						acc
-					});
-			
-				let (tx, rx) = oneshot::channel();
-				sender
-					.send_message(
-						AvailabilityStoreMessage::NoteBackableCandidates{ candidate_hashes: candidate_hashes, num_validators, tx },
+				let candidate_hashes = scheduled_cores.iter().map(|(_, core_info)| core_info.candidate_hash).collect::<HashSet<_>>();
+				
+				let session_info = self
+					.session_cache
+					.get_session_info(
+						ctx,
+						runtime,
+						// We use leaf here, the relay_parent must be in the same session as
+						// the leaf. This is guaranteed by runtime which ensures that cores are
+						// cleared at session boundaries. At the same time, only leaves are
+						// guaranteed to be fetchable by the state trie.
+						leaf,
+						leaf_session_index,
 					)
-					.await;
-				if let Err(err) = rx.await {
-					gum::error!(target: LOG_TARGET, "Sending NoteBackableCandidate message failed: {:?}", err);
+					.await
+					.map_err(|err| {
+						gum::warn!(
+							target: LOG_TARGET,
+							error = ?err,
+							"Failed to spawn a fetch task"
+						);
+						err
+					})?;
+
+				if let Some(session_info) = session_info {
+					let num_validators =
+						session_info.validator_groups.iter().fold(0usize, |mut acc, group| {
+							acc = acc.saturating_add(group.len());
+							acc
+						});
+				
+					let (tx, rx) = oneshot::channel();
+					sender
+						.send_message(
+							AvailabilityStoreMessage::NoteBackableCandidates{ candidate_hashes: candidate_hashes, num_validators, tx },
+						)
+						.await;
+					if let Err(err) = rx.await {
+						gum::error!(target: LOG_TARGET, "Sending NoteBackableCandidate message failed: {:?}", err);
+					} else {
+						self.add_cores(ctx, runtime, leaf, leaf_session_index, scheduled_cores).await?;
+					}
 				}
-				self.add_cores(ctx, runtime, leaf, leaf_session_index, scheduled_cores).await?;
 			}
 		}
 		Ok(())

--- a/polkadot/node/overseer/src/lib.rs
+++ b/polkadot/node/overseer/src/lib.rs
@@ -520,6 +520,8 @@ pub struct Overseer<SupportsParachains> {
 		ChainApiMessage,
 		RuntimeApiMessage,
 		NetworkBridgeTxMessage,
+		ProspectiveParachainsMessage,
+		CandidateBackingMessage
 	])]
 	availability_distribution: AvailabilityDistribution,
 

--- a/polkadot/node/service/src/builder/mod.rs
+++ b/polkadot/node/service/src/builder/mod.rs
@@ -98,6 +98,8 @@ pub struct NewFullParams<OverseerGenerator: OverseerGen> {
 	pub invulnerable_ah_collators: HashSet<polkadot_node_network_protocol::PeerId>,
 	/// Override for `HOLD_OFF_DURATION` constant .
 	pub collator_protocol_hold_off: Option<Duration>,
+	/// Enable speculative availability requests via Prospective Parachains.
+	pub speculative_availability: bool,
 }
 
 /// Completely built polkadot node service.
@@ -209,6 +211,7 @@ where
 					keep_finalized_for,
 					invulnerable_ah_collators,
 					collator_protocol_hold_off,
+					speculative_availability,
 				},
 			overseer_connector,
 			partial_components:
@@ -452,6 +455,7 @@ where
 				fetch_chunks_threshold,
 				invulnerable_ah_collators,
 				collator_protocol_hold_off,
+				speculative_availability,
 			})
 		};
 

--- a/polkadot/node/service/src/overseer.rs
+++ b/polkadot/node/service/src/overseer.rs
@@ -147,6 +147,8 @@ pub struct ExtendedOverseerGenArgs {
 	pub invulnerable_ah_collators: HashSet<polkadot_node_network_protocol::PeerId>,
 	/// Override for `HOLD_OFF_DURATION` constant .
 	pub collator_protocol_hold_off: Option<Duration>,
+	/// Whether speculative availability requests are enabled.
+	pub speculative_availability: bool,
 }
 
 /// Obtain a prepared validator `Overseer`, that is initialized with all default values.
@@ -183,6 +185,7 @@ pub fn validator_overseer_builder<Spawner, RuntimeClient>(
 		fetch_chunks_threshold,
 		invulnerable_ah_collators,
 		collator_protocol_hold_off,
+		speculative_availability,
 	}: ExtendedOverseerGenArgs,
 ) -> Result<
 	InitializedOverseerBuilder<
@@ -262,6 +265,7 @@ where
 			},
 			req_protocol_names.clone(),
 			Metrics::register(registry)?,
+			speculative_availability,
 		))
 		.availability_recovery(AvailabilityRecoverySubsystem::for_validator(
 			fetch_chunks_threshold,

--- a/polkadot/node/subsystem-types/src/messages.rs
+++ b/polkadot/node/subsystem-types/src/messages.rs
@@ -572,6 +572,15 @@ pub enum AvailabilityStoreMessage {
 		tx: oneshot::Sender<Result<(), ()>>,
 	},
 
+	/// Note that a candidate is backable. Only used by Speculative Availability to signal to Availability Store
+	/// that it should keep track of this candidate and it is highly likely the candidate will be backed.
+	NoteBackableCandidate{
+		/// A hash of the backable candidate.
+		candidate_hash: CandidateHash,
+		/// Sending side of the channel to send result to.
+		tx: oneshot::Sender<Result<(), ()>>,
+	},
+
 	/// Computes and checks the erasure root of `AvailableData` before storing all of its chunks in
 	/// the AV store.
 	///

--- a/polkadot/node/subsystem-types/src/messages.rs
+++ b/polkadot/node/subsystem-types/src/messages.rs
@@ -574,9 +574,11 @@ pub enum AvailabilityStoreMessage {
 
 	/// Note that a candidate is backable. Only used by Speculative Availability to signal to Availability Store
 	/// that it should keep track of this candidate and it is highly likely the candidate will be backed.
-	NoteBackableCandidate{
+	NoteBackableCandidates{
 		/// A hash of the backable candidate.
-		candidate_hash: CandidateHash,
+		candidate_hashes: HashSet<CandidateHash>,
+		/// The number of validators in the session.
+		num_validators: usize,
 		/// Sending side of the channel to send result to.
 		tx: oneshot::Sender<Result<(), ()>>,
 	},

--- a/polkadot/node/subsystem-util/Cargo.toml
+++ b/polkadot/node/subsystem-util/Cargo.toml
@@ -12,6 +12,7 @@ repository.workspace = true
 workspace = true
 
 [dependencies]
+bitvec = { workspace = true }
 codec = { features = ["derive"], workspace = true }
 fatality = { workspace = true }
 futures = { workspace = true }

--- a/polkadot/node/subsystem-util/src/lib.rs
+++ b/polkadot/node/subsystem-util/src/lib.rs
@@ -40,21 +40,24 @@ pub use polkadot_node_metrics::{metrics, Metronome};
 use codec::Encode;
 use futures::channel::{mpsc, oneshot};
 
+use bitvec::vec::BitVec;
+use bitvec;
+
 use polkadot_primitives::{
 	async_backing::{BackingState, Constraints},
 	slashing, AsyncBackingParams, AuthorityDiscoveryId, CandidateEvent, CandidateHash,
 	CommittedCandidateReceiptV2 as CommittedCandidateReceipt, CoreIndex, CoreState, EncodeAs,
 	ExecutorParams, GroupIndex, GroupRotationInfo, Hash, Id as ParaId, NodeFeatures,
 	OccupiedCoreAssumption, PersistedValidationData, ScrapedOnChainVotes, SessionIndex,
-	SessionInfo, Signed, SigningContext, ValidationCode, ValidationCodeHash, ValidatorId,
-	ValidatorIndex, ValidatorSignature,
+	SessionInfo, Signed, SignedAvailabilityBitfield, SigningContext, ValidationCode,
+	ValidationCodeHash, ValidatorId, ValidatorIndex, ValidatorSignature,
 };
 pub use rand;
 use sp_application_crypto::AppCrypto;
 use sp_core::ByteArray;
 use sp_keystore::{Error as KeystoreError, KeystorePtr};
 use std::{
-	collections::{BTreeMap, VecDeque},
+	collections::{BTreeMap, HashMap, VecDeque},
 	time::Duration,
 };
 use thiserror::Error;
@@ -98,6 +101,10 @@ mod determine_new_blocks;
 
 mod controlled_validator_indices;
 pub use controlled_validator_indices::ControlledValidatorIndices;
+use polkadot_node_subsystem_types::{
+	messages::{Ancestors, ProspectiveParachainsMessage},
+	ActivatedLeaf,
+};
 
 #[cfg(test)]
 mod tests;
@@ -139,6 +146,10 @@ pub enum Error {
 	/// Data that are supposed to be there a not there
 	#[error("Data are not available")]
 	DataNotAvailable,
+	/// Attempted to get backable candidates from prospective parachains but the request was
+	/// canceled.
+	#[error("failed to get backable candidates from prospective parachains")]
+	CanceledBackableCandidates(#[source] oneshot::Canceled),
 }
 
 impl From<OverseerError> for Error {
@@ -542,4 +553,245 @@ impl Validator {
 	) -> Result<Option<Signed<Payload, RealPayload>>, KeystoreError> {
 		Signed::sign(&keystore, payload, &self.signing_context, self.index, &self.key)
 	}
+}
+
+/// In general, we want to pick all the bitfields. However, we have the following constraints:
+///
+/// - not more than one per validator
+/// - each 1 bit must correspond to an occupied core
+///
+/// If we have too many, an arbitrary selection policy is fine. For purposes of maximizing
+/// availability, we pick the one with the greatest number of 1 bits.
+///
+/// Note: This does not enforce any sorting precondition on the output; the ordering there will be
+/// unrelated to the sorting of the input.
+pub fn select_availability_bitfields(
+	cores: &[CoreState],
+	bitfields: &[SignedAvailabilityBitfield],
+	leaf_hash: &Hash,
+) -> Vec<SignedAvailabilityBitfield> {
+	let mut selected: BTreeMap<ValidatorIndex, SignedAvailabilityBitfield> = BTreeMap::new();
+
+	gum::debug!(
+		target: LOG_TARGET,
+		bitfields_count = bitfields.len(),
+		?leaf_hash,
+		"bitfields count before selection"
+	);
+
+	'a: for bitfield in bitfields.iter().cloned() {
+		if bitfield.payload().0.len() != cores.len() {
+			gum::debug!(target: LOG_TARGET, ?leaf_hash, "dropping bitfield due to length mismatch");
+			continue
+		}
+
+		let is_better = selected
+			.get(&bitfield.validator_index())
+			.map_or(true, |b| b.payload().0.count_ones() < bitfield.payload().0.count_ones());
+
+		if !is_better {
+			gum::trace!(
+				target: LOG_TARGET,
+				val_idx = bitfield.validator_index().0,
+				?leaf_hash,
+				"dropping bitfield due to duplication - the better one is kept"
+			);
+			continue
+		}
+
+		for (idx, _) in cores.iter().enumerate().filter(|v| !v.1.is_occupied()) {
+			// Bit is set for an unoccupied core - invalid
+			if *bitfield.payload().0.get(idx).as_deref().unwrap_or(&false) {
+				gum::debug!(
+					target: LOG_TARGET,
+					val_idx = bitfield.validator_index().0,
+					?leaf_hash,
+					"dropping invalid bitfield - bit is set for an unoccupied core"
+				);
+				continue 'a
+			}
+		}
+
+		let _ = selected.insert(bitfield.validator_index(), bitfield);
+	}
+
+	gum::debug!(
+		target: LOG_TARGET,
+		?leaf_hash,
+		"selected {} of all {} bitfields (each bitfield is from a unique validator)",
+		selected.len(),
+		bitfields.len()
+	);
+
+	selected.into_values().collect()
+}
+
+/// Requests backable candidates from Prospective Parachains subsystem
+/// based on core states.
+pub async fn request_backable_candidates(
+	availability_cores: &[CoreState],
+	bitfields: Option<&[SignedAvailabilityBitfield]>,
+	relay_parent: &ActivatedLeaf,
+	sender: &mut impl overseer::SubsystemSender<ProspectiveParachainsMessage>,
+) -> Result<HashMap<ParaId, Vec<(CandidateHash, Hash)>>, Error> {
+	let block_number_under_construction = relay_parent.number + 1;
+
+	// Record how many cores are scheduled for each paraid. Use a BTreeMap because
+	// we'll need to iterate through them.
+	let mut scheduled_cores_per_para: BTreeMap<ParaId, usize> = BTreeMap::new();
+	// The on-chain ancestors of a para present in availability-cores.
+	let mut ancestors: HashMap<ParaId, Ancestors> =
+		HashMap::with_capacity(availability_cores.len());
+
+	for (core_idx, core) in availability_cores.iter().enumerate() {
+		let core_idx = CoreIndex(core_idx as u32);
+		match core {
+			CoreState::Scheduled(scheduled_core) => {
+				*scheduled_cores_per_para.entry(scheduled_core.para_id).or_insert(0) += 1;
+			},
+			CoreState::Occupied(occupied_core) => {
+				let is_available = match bitfields {
+					Some(bitfields) => {
+						// If bitfields are provided, check if the core is available.
+						bitfields_indicate_availability(
+							core_idx.0 as usize,
+							bitfields,
+							&occupied_core.availability,
+						)
+					},
+					None => {
+						gum::debug!(
+							target: LOG_TARGET,
+							leaf_hash = ?relay_parent.hash,
+							?core_idx,
+							"No availability bitfields provided, assuming core is available"
+						);
+						true
+					},
+				};
+
+				if is_available {
+					ancestors
+						.entry(occupied_core.para_id())
+						.or_default()
+						.insert(occupied_core.candidate_hash);
+
+					if let Some(ref scheduled_core) = occupied_core.next_up_on_available {
+						// Request a new backable candidate for the newly scheduled para id.
+						*scheduled_cores_per_para.entry(scheduled_core.para_id).or_insert(0) += 1;
+					}
+				} else if occupied_core.time_out_at <= block_number_under_construction {
+					// Timed out before being available.
+
+					if let Some(ref scheduled_core) = occupied_core.next_up_on_time_out {
+						// Candidate's availability timed out, practically same as scheduled.
+						*scheduled_cores_per_para.entry(scheduled_core.para_id).or_insert(0) += 1;
+					}
+				} else {
+					// Not timed out and not available.
+					ancestors
+						.entry(occupied_core.para_id())
+						.or_default()
+						.insert(occupied_core.candidate_hash);
+				}
+			},
+			CoreState::Free => continue,
+		};
+	}
+
+	let mut selected_candidates: HashMap<ParaId, Vec<(CandidateHash, Hash)>> =
+		HashMap::with_capacity(scheduled_cores_per_para.len());
+
+	for (para_id, core_count) in scheduled_cores_per_para {
+		let para_ancestors = ancestors.remove(&para_id).unwrap_or_default();
+
+		let response = get_backable_candidates(
+			relay_parent.hash,
+			para_id,
+			para_ancestors,
+			core_count as u32,
+			sender,
+		)
+		.await?;
+
+		if response.is_empty() {
+			gum::debug!(
+				target: LOG_TARGET,
+				leaf_hash = ?relay_parent.hash,
+				?para_id,
+				"No backable candidate returned by prospective parachains",
+			);
+			continue;
+		}
+
+		selected_candidates.insert(para_id, response);
+	}
+
+	Ok(selected_candidates)
+}
+
+/// The availability bitfield for a given core.
+pub type CoreAvailability = BitVec<u8, bitvec::order::Lsb0>;
+
+/// The availability bitfield for a given core is the transpose
+/// of a set of signed availability bitfields. It goes like this:
+///
+/// - construct a transverse slice along `core_idx`
+/// - bitwise-or it with the availability slice
+/// - count the 1 bits, compare to the total length; true on 2/3+
+fn bitfields_indicate_availability(
+	core_idx: usize,
+	bitfields: &[SignedAvailabilityBitfield],
+	availability: &CoreAvailability,
+) -> bool {
+	let mut availability = availability.clone();
+	let availability_len = availability.len();
+
+	for bitfield in bitfields {
+		let validator_idx = bitfield.validator_index().0 as usize;
+		match availability.get_mut(validator_idx) {
+			None => {
+				// in principle, this function might return a `Result<bool, Error>` so that we can
+				// more clearly express this error condition however, in practice, that would just
+				// push off an error-handling routine which would look a whole lot like this one.
+				// simpler to just handle the error internally here.
+				gum::warn!(
+					target: LOG_TARGET,
+					validator_idx = %validator_idx,
+					availability_len = %availability_len,
+					"attempted to set a transverse bit at idx {} which is greater than bitfield size {}",
+					validator_idx,
+					availability_len,
+				);
+
+				return false;
+			},
+			Some(mut bit_mut) => *bit_mut |= bitfield.payload().0[core_idx],
+		}
+	}
+
+	3 * availability.count_ones() >= 2 * availability.len()
+}
+
+/// Requests backable candidates from Prospective Parachains based on
+/// the given ancestors in the fragment chain. The ancestors may not be ordered.
+async fn get_backable_candidates(
+	relay_parent: Hash,
+	para_id: ParaId,
+	ancestors: Ancestors,
+	count: u32,
+	sender: &mut impl overseer::SubsystemSender<ProspectiveParachainsMessage>,
+) -> Result<Vec<(CandidateHash, Hash)>, Error> {
+	let (tx, rx) = oneshot::channel();
+	sender
+		.send_message(ProspectiveParachainsMessage::GetBackableCandidates(
+			relay_parent,
+			para_id,
+			count,
+			ancestors,
+			tx,
+		))
+		.await;
+
+	rx.await.map_err(Error::CanceledBackableCandidates)
 }

--- a/polkadot/zombienet-sdk-tests/tests/functional/async_backing_6_seconds_rate.rs
+++ b/polkadot/zombienet-sdk-tests/tests/functional/async_backing_6_seconds_rate.rs
@@ -84,6 +84,14 @@ async fn async_backing_6_seconds_rate_test() -> Result<(), anyhow::Error> {
 	)
 	.await?;
 
+	let scheduled_metric_name = "polkadot_parachain_fetched_chunks_total{origin=\"scheduled\",success=\"succeeded\"}";
+	// scheduled chunk fetches should be 0 since speculative availability is disabled
+	assert!(relay_node.assert_with(scheduled_metric_name, |v| {v == 0.0}).await?);
+
+	let occupied_metric_name = "polkadot_parachain_fetched_chunks_total{origin=\"occupied\",success=\"succeeded\"}";
+	// all requests should be occupied since speculative availability is disabled
+	assert!(relay_node.assert_with(occupied_metric_name, |v| {v >= 22.0 && v <= 40.0}).await?);
+
 	// Assert the parachain finalized block height is also on par with the number of backed
 	// candidates. We can only do this for the collator based on cumulus.
 	assert_finality_lag(&para_node_2001.wait_client().await?, 6).await?;

--- a/polkadot/zombienet-sdk-tests/tests/functional/mod.rs
+++ b/polkadot/zombienet-sdk-tests/tests/functional/mod.rs
@@ -6,6 +6,7 @@ mod approved_peer_mixed_validators;
 mod async_backing_6_seconds_rate;
 mod dispute_old_finalized;
 mod duplicate_collations;
+mod speculative_availability_requests;
 mod shared_core_idle_parachain;
 mod spam_statement_distribution_requests;
 mod sync_backing;

--- a/polkadot/zombienet-sdk-tests/tests/functional/speculative_availability_requests.rs
+++ b/polkadot/zombienet-sdk-tests/tests/functional/speculative_availability_requests.rs
@@ -1,0 +1,89 @@
+// Copyright (C) Parity Technologies (UK) Ltd.
+// SPDX-License-Identifier: Apache-2.0
+
+// Test we are producing 12-second parachain blocks if using an old collator, pre async-backing.
+
+use anyhow::anyhow;
+
+use cumulus_zombienet_sdk_helpers::{assert_finality_lag, assert_para_throughput};
+use polkadot_primitives::Id as ParaId;
+use serde_json::json;
+use zombienet_sdk::{
+	subxt::{OnlineClient, PolkadotConfig},
+	NetworkConfigBuilder,
+};
+
+#[tokio::test(flavor = "multi_thread")]
+async fn speculative_availability_requests_test() -> Result<(), anyhow::Error> {
+	let _ = env_logger::try_init_from_env(
+		env_logger::Env::default().filter_or(env_logger::DEFAULT_FILTER_ENV, "info"),
+	);
+
+	let images = zombienet_sdk::environment::get_images_from_env();
+
+	let config = NetworkConfigBuilder::new()
+		.with_relaychain(|r| {
+			let r = r
+				.with_chain("rococo-local")
+				.with_default_command("polkadot")
+				.with_default_image(images.polkadot.as_str())
+				.with_default_args(vec![("-lparachain=debug").into()])
+				.with_genesis_overrides(json!({
+					"configuration": {
+						"config": {
+							"scheduler_params": {
+								"group_rotation_frequency": 4
+							}
+						}
+					}
+				}))
+				.with_node(|node| node.with_name("validator-0"));
+
+			(1..12)
+				.fold(r, |acc, i| acc.with_node(|node| node.with_name(&format!("validator-{i}"))))
+		})
+		.with_parachain(|p| {
+			p.with_id(2000)
+				.with_default_command("polkadot-parachain")
+				.with_default_image(images.cumulus.as_str())
+				.with_default_args(vec![("-lparachain=debug,aura=debug").into()])
+				.with_collator(|n| n.with_name("collator-2000"))
+		})
+		.with_parachain(|p| {
+			p.with_id(2001)
+				.with_default_command("polkadot-parachain")
+				.with_default_image(images.cumulus.as_str())
+				.with_default_args(vec![("-lparachain=debug,aura=debug").into()])
+				.with_collator(|n| n.with_name("collator-2001"))
+		})
+		.build()
+		.map_err(|e| {
+			let errs = e.into_iter().map(|e| e.to_string()).collect::<Vec<_>>().join(" ");
+			anyhow!("config errs: {errs}")
+		})?;
+
+	let spawn_fn = zombienet_sdk::environment::get_spawn_fn();
+	let network = spawn_fn(config).await?;
+
+	let relay_node = network.get_node("validator-0")?;
+	let para_node_2001 = network.get_node("collator-2001")?;
+
+	let relay_client: OnlineClient<PolkadotConfig> = relay_node.wait_client().await?;
+
+	assert_para_throughput(
+		&relay_client,
+		15,
+		[(ParaId::from(2000), 11..16), (ParaId::from(2001), 11..16)]
+			.into_iter()
+			.collect(),
+	)
+	.await?;
+
+	// Assert the parachain finalized block height is also on par with the number of backed
+	// candidates. We can only do this for the collator based on cumulus.
+	assert_finality_lag(&para_node_2001.wait_client().await?, 6).await?;
+
+	log::info!("Test finished successfully");
+
+	Ok(())
+}

--- a/polkadot/zombienet-sdk-tests/tests/functional/speculative_availability_requests.rs
+++ b/polkadot/zombienet-sdk-tests/tests/functional/speculative_availability_requests.rs
@@ -27,7 +27,7 @@ async fn speculative_availability_requests_test() -> Result<(), anyhow::Error> {
 				.with_chain("rococo-local")
 				.with_default_command("polkadot")
 				.with_default_image(images.polkadot.as_str())
-				.with_default_args(vec![("-lparachain=debug").into()])
+				.with_default_args(vec![("-lparachain=debug", "--speculative-availability").into()])
 				.with_genesis_overrides(json!({
 					"configuration": {
 						"config": {

--- a/polkadot/zombienet-sdk-tests/tests/functional/speculative_availability_requests.rs
+++ b/polkadot/zombienet-sdk-tests/tests/functional/speculative_availability_requests.rs
@@ -79,6 +79,15 @@ async fn speculative_availability_requests_test() -> Result<(), anyhow::Error> {
 	)
 	.await?;
 
+	let scheduled_metric_name = "polkadot_parachain_fetched_chunks_total{origin=\"scheduled\",success=\"succeeded\"}";
+	// scheduled chunk fetches should be more than the asserted para throughput given blocks are still produced
+	assert!(relay_node.assert_with(scheduled_metric_name, |v| {v >= 22.0 && v <= 40.0}).await?);
+	
+	let occupied_metric_name = "polkadot_parachain_fetched_chunks_total{origin=\"occupied\",success=\"succeeded\"}";
+	// given when speculative availability is requested on active leaves update, there may not be any backable 
+	// candidates from Prospective Parachains at that the time.
+	assert!(relay_node.assert_with(occupied_metric_name, |v| {v >= 2.0 && v <= 10.0}).await?);
+
 	// Assert the parachain finalized block height is also on par with the number of backed
 	// candidates. We can only do this for the collator based on cumulus.
 	assert_finality_lag(&para_node_2001.wait_client().await?, 6).await?;

--- a/polkadot/zombienet-sdk-tests/tests/functional/speculative_availability_requests.rs
+++ b/polkadot/zombienet-sdk-tests/tests/functional/speculative_availability_requests.rs
@@ -1,7 +1,8 @@
 // Copyright (C) Parity Technologies (UK) Ltd.
 // SPDX-License-Identifier: Apache-2.0
 
-// Test we are producing 12-second parachain blocks if using an old collator, pre async-backing.
+// Test we are producing 12-second parachain blocks if using 2x async-backing parachains,
+// ensure that chunk fetch requests are being made speculatively.
 
 use anyhow::anyhow;
 


### PR DESCRIPTION
Re-implementation of https://github.com/paritytech/polkadot-sdk/pull/9444 to better understand fetching logic and backable candidate retrieval.  Contains a hack in av-store to store the metadata of a chunk when receiving a store chunk request.  Early requests were silently failing, since the `RunningTask.store_chunk` method does not return a result and the error was not logged out correctly.